### PR TITLE
Fix `writeAlloc`, use new writer API

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,7 +3,7 @@
     .name = .bincode,
     // This is a [Semantic Version](https://semver.org/).
     // In a future version of Zig it will be used for package deduplication.
-    .version = "0.15.0",
+    .version = "0.15.1",
 
     // This field is optional.
     // This is currently advisory only; Zig does not yet do anything


### PR DESCRIPTION
#### Problem

`writeAlloc` doesn't work currently, and the package is still using the old writer API.

#### Summary of changes

Fix `writeAlloc`, and use the new API.